### PR TITLE
Makes layout of symptoms question consistent with the others

### DIFF
--- a/src/views/symptoms.hbs
+++ b/src/views/symptoms.hbs
@@ -53,6 +53,7 @@
 
     <li class="f5 black-60 db mb2 tracked pt3 pb3 mr2"><span class='li mr2 w2'>&rarr;</span>
       What helps to keep you well? (e.g friends, support from family?)
+      <br>
       <textarea class="mt3 w-80 mw7 vh-5 ba b--black-30 br3 h4" type="text" name="keep_well" rows="8" cols="80" placeholder="Write here please" aria-label='what helps keep you well'>{{data.keep_well}}</textarea>
     </li>
   </ol>


### PR DESCRIPTION
#103 Other questions had a <br> between question text and text box, which stops the text from being broken up on small screens (part of the text showing above the text box, part below).