### PR TITLE
Fixes typo on home page

### DIFF
--- a/src/views/home.hbs
+++ b/src/views/home.hbs
@@ -15,7 +15,7 @@
      <a class="no-underline" href="/send"><button class="margin-0-auto flex flex-wrap justify-center grey-font bn bg-white-60 vh-25 w-75 br3 mw6 mb3 grow" type="button" name="send" aria-label="send your form">
        <div class="tc">
          <h3 class="tracked">
-           Send your from
+           Send your form
          </h3>
          <img src="https://iconmonstr.com/wp-content/g/gd/makefg.php?i=../assets/preview/2013/png/iconmonstr-paper-plane-8.png&r=79&g=79&b=79" alt="edit icon" class="contain h3 w3 dib pa2">
        </div>


### PR DESCRIPTION
#125 Fixes typo on home page ('send your from' is now 'send your form')