### PR TITLE
Redirect if email already registered

### DIFF
--- a/src/controllers/signup.js
+++ b/src/controllers/signup.js
@@ -45,9 +45,7 @@ exports.post = (req, res) => {
             });
         } else {
           req.flash('error', `Account already exists for ${userData.email}`);
-          res.status(200).render('signup', {
-            pageTitle: 'Create an Account',
-          });
+          res.redirect('signup');
         }
       })
       .catch((err) => {


### PR DESCRIPTION
Error message wasn't showing on signup page if email already registered #152 - redirecting instead of rendering fixes this