### PR TITLE
No longer tries to add undefined to body classList

### DIFF
--- a/public/change_colour.js
+++ b/public/change_colour.js
@@ -8,17 +8,19 @@
 
   // Get value of cookie 'name'
   function getCookie(name) {
-    var allCookies = document.cookie.split('; ');
+    var allCookies = document.cookie ? document.cookie.split('; ') : [];
     var myCookie = allCookies.find(function(cookie) {
       return cookie.includes('theme=');
     });
-    return myCookie.split('=')[1] || '';
+    return myCookie ? myCookie.split('=')[1] : '';
   }
 
   // Check if theme has been set
   var theme = getCookie('theme');
-  document.body.classList = '';
-  document.body.classList.add(theme);
+  if (theme) {
+    document.body.classList = '';
+    document.body.classList.add(theme);
+  }
 
   var themes = [
     'yellow-red',


### PR DESCRIPTION
#167 If no cookies were set on document, errors would occur as we would be trying to split undefined. 

If the theme wasn't set, error would occur when trying to add 'undefined' to classList of body.